### PR TITLE
remove invalid `type: string` from Contact property in Quote schema

### DIFF
--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -24128,7 +24128,6 @@ components:
           type: string
         Contact:
           $ref: '#/components/schemas/Contact'
-          type: string
         LineItems:
           description: See LineItems
           type: array


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Remove extraneous `type: string` from the Contact field of the Quote schema