### PR TITLE
GET Payments fix

### DIFF
--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -11664,7 +11664,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Payments'
+                $ref: '#/components/schemas/PaymentsRead'
               example:
                 Id: 9f310473-e1b5-4704-a25c-eec653deb596
                 Status: OK
@@ -12148,7 +12148,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Payments'
+                $ref: '#/components/schemas/PaymentsRead'
               example:
                 Id: 4876f9ee-3a17-47d8-8c1b-84377c8f2998
                 Status: OK
@@ -23860,6 +23860,141 @@ components:
           items:
             $ref: '#/components/schemas/ValidationError'
       type: object
+    PaymentRead:
+      externalDocs:
+        url: http://developer.xero.com/documentation/api/payments/
+      required:
+        - PaymentID
+      properties:
+        Invoice:
+          $ref: '#/components/schemas/Invoice'
+        CreditNote:
+          $ref: '#/components/schemas/CreditNote'
+        Prepayment:
+          $ref: '#/components/schemas/Prepayment'
+        Overpayment:
+          $ref: '#/components/schemas/Overpayment'
+        InvoiceNumber:
+          description: Number of invoice or credit note you are applying payment to e.g.INV-4003
+          type: string
+        CreditNoteNumber:
+          description: Number of invoice or credit note you are applying payment to e.g. INV-4003
+          type: string
+        BatchPayment:
+          $ref: '#/components/schemas/BatchPayment'
+        Account:
+          $ref: '#/components/schemas/Account'
+        Code:
+          description: Code of account you are using to make the payment e.g. 001 (note- not all accounts have a code value)
+          type: string
+        Date:
+          description: Date the payment is being made (YYYY-MM-DD) e.g. 2009-09-06
+          type: string
+          x-is-msdate: true
+        CurrencyRate:
+          description: Exchange rate when payment is received. Only used for non base currency invoices and credit notes e.g. 0.7500
+          type: number
+          format: double
+          x-is-money: true
+        Amount:
+          description: The amount of the payment. Must be less than or equal to the outstanding amount owing on the invoice e.g. 200.00
+          type: number
+          format: double
+          x-is-money: true
+        BankAmount:
+          description: The amount of the payment in the currency of the bank account.
+          type: number
+          format: double
+          x-is-money: true
+        Reference:
+          description: An optional description for the payment e.g. Direct Debit
+          type: string
+        IsReconciled:
+          description: An optional parameter for the payment. A boolean indicating whether you would like the payment to be created as reconciled when using PUT, or whether a payment has been reconciled when using GET
+          type: boolean
+        Status:
+          description: The status of the payment.
+          type: string
+          enum:
+            - AUTHORISED
+            - DELETED
+        PaymentType:
+          description: See Payment Types.
+          readOnly: true
+          type: string
+          enum:
+            - ACCRECPAYMENT
+            - ACCPAYPAYMENT
+            - ARCREDITPAYMENT
+            - APCREDITPAYMENT
+            - AROVERPAYMENTPAYMENT
+            - ARPREPAYMENTPAYMENT
+            - APPREPAYMENTPAYMENT
+            - APOVERPAYMENTPAYMENT
+        UpdatedDateUTC:
+          description: UTC timestamp of last update to the payment
+          type: string
+          x-is-msdate-time: true
+          example: /Date(1573755038314)/
+          readOnly: true
+        PaymentID:
+          description: The Xero identifier for an Payment e.g. 297c2dc5-cc47-4afd-8ec8-74990b8761e9
+          type: string
+          format: uuid
+          example: 00000000-0000-0000-0000-000000000000
+        BatchPaymentID:
+          description: Present if the payment was created as part of a batch.
+          type: string
+          format: uuid
+          example: 00000000-0000-0000-0000-000000000000
+        BankAccountNumber:
+          description: The suppliers bank account number the payment is being made to
+          type: string
+        Particulars:
+          description: The suppliers bank account number the payment is being made to
+          type: string
+        Details:
+          description: The information to appear on the supplier's bank account
+          type: string
+        HasAccount:
+          description: A boolean to indicate if a contact has an validation errors
+          type: boolean
+          default: "false"
+          example: "false"
+        HasValidationErrors:
+          description: A boolean to indicate if a contact has an validation errors
+          type: boolean
+          default: "false"
+          example: "false"
+        StatusAttributeString:
+          description: A string to indicate if a invoice status
+          type: string
+        ValidationErrors:
+          description: Displays array of validation error messages from the API
+          type: array
+          items:
+            $ref: '#/components/schemas/ValidationError'
+        Warnings:
+          description: Displays array of warning messages from the API
+          type: array
+          items:
+            $ref: '#/components/schemas/ValidationError'
+      type: object
+    PaymentsRead:
+      type: object
+      x-objectArrayKey: payments
+      properties:
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+        Warnings:
+          description: Displays array of warning messages from the API
+          type: array
+          items:
+            $ref: '#/components/schemas/ValidationError'
+        Payments:
+          type: array
+          items:
+            $ref: '#/components/schemas/PaymentRead'
     Prepayments:
       type: object
       x-objectArrayKey: prepayments


### PR DESCRIPTION
For GET Payment requests the Xero API doesn't always return an Account field. This causes validation errors when trying to retrieve payments in the generated sdk. I added a new response type called PaymentRead with more relaxed requirements for GET requests instead of the original Payment that's still used for POST/PUT requests. 
